### PR TITLE
fix development command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,9 +110,9 @@
     "scripts": {
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "development-disable": "zf-development-mode disable",
-        "development-enable": "zf-development-mode enable",
-        "development-status": "zf-development-mode status",
+        "development-disable": "laminas-development-mode disable",
+        "development-enable": "laminas-development-mode enable",
+        "development-status": "laminas-development-mode status",
         "post-create-project-cmd": [
             "@development-enable",
             "php -r '$file = file_get_contents(\".gitignore\"); $file = str_replace(\"composer.lock\", \"\", $file); file_put_contents(\".gitignore\", $file);'"


### PR DESCRIPTION
Change "zf" to "laminas":

Before:

```bash
composer development-enable
> zf-development-mode enable
sh: zf-development-mode: command not found
```

After:

```bash
composer development-enable
> laminas-development-mode enable
You are now in development mode.
```

/cc @Xerkus 