### PR TITLE
fix 404 got error is_file() expects parameter 1 to be a valid path, bool given

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -14,7 +14,7 @@ chdir(dirname(__DIR__));
 // Decline static file requests back to the PHP built-in webserver
 if (php_sapi_name() === 'cli-server') {
     $path = realpath(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
-    if (__FILE__ !== $path && is_file($path)) {
+    if ($path && __FILE__ !== $path && is_file($path)) {
         return false;
     }
     unset($path);

--- a/public/index.php
+++ b/public/index.php
@@ -14,7 +14,7 @@ chdir(dirname(__DIR__));
 // Decline static file requests back to the PHP built-in webserver
 if (php_sapi_name() === 'cli-server') {
     $path = realpath(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
-    if ($path && __FILE__ !== $path && is_file($path)) {
+    if (is_string($path) && __FILE__ !== $path && is_file($path)) {
         return false;
     }
     unset($path);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no

### Description

when using php cli server, try open 404 page, got error:

![Screen Shot 2020-01-03 at 9 03 02 PM](https://user-images.githubusercontent.com/459648/71727325-75726b80-2e6c-11ea-8118-a7dce50ca2c4.png)

It because the passed data to `is_file()` can be false as bool. Updated with truthy check first fix it.

Edit: tested in PHP 7.4