### PR TITLE
Provide descriptions for commands exposed via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,5 +119,14 @@
         ],
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"
+    },
+    "scripts-descriptions": {
+        "cs-check": "Run coding standards checks.",
+        "cs-fix": "Automatically fix coding standard issues.",
+        "development-disable": "Disable development mode.",
+        "development-enable": "Enable development mode.",
+        "development-status": "Detail whether or not the application is in development mode.",
+        "serve": "Start the built-in PHP web server and serve the application.",
+        "test": "Run unit tests."
     }
 }


### PR DESCRIPTION
Composer supports a "scripts-descriptions" setting, which is an object where keys are the script names, and their values the descriptions.  These are then used during a `list` operation (or running `composer` without arguments) to detail the purpose of the script.

This patch provides descriptions for all commands except `post-create-project-command`, which is removed following project creation.