### PR TITLE
remove use_laminas_loader config in when module-manager drop its support

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -14,9 +14,6 @@ return [
 
     // These are various options for the listeners attached to the ModuleManager
     'module_listener_options' => [
-        // use composer autoloader instead of laminas-loader
-        'use_laminas_loader' => false,
-
         // An array of paths from which to glob configuration files after
         // modules are loaded. These effectively override configuration
         // provided by modules themselves. Paths may use GLOB_BRACE notation.


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

|    Q          |   A
|-------------- | ------
| BC Break      | yes

When https://github.com/laminas/laminas-modulemanager/pull/12 applied.


<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
