### PR TITLE
Adds CHANGELOG entries for 1.0.0 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /.github/ export-ignore
 /bin/remove-package-artifacts.php export-ignore
+/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## 1.0.0 - TBD
 
+This is the initial 1.0.0 release under the Laminas organization.
+
 ### Added
 
-- Nothing.
+- Adds descriptions for shipped Composer commands.
 
 ### Changed
 
-- Nothing.
+- Bumps the minimum supported PHP version to 7.3.
+
+- Improves the shipped Dockerfile and default extensions available.
 
 ### Deprecated
 
@@ -18,8 +22,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- Removes the `public/index.html` page, which could lead to display of the default Apache2 landing page.
 
 ### Fixed
 
-- Nothing.
+- Ensures initial page presentation looks as expected, including logo display, no duplication, proper 404 display, etc.
+
+- Ensures Zend Framework is no longer referenced in all commands, documentation, and default pages.

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,8 @@
         "post-create-project-cmd": [
             "@development-enable",
             "php bin/update-gitignore.php",
-            "php -r 'if (file_exists(\"bin/remove-package-artifacts.php\")) include \"bin/remove-package-artifacts.php\";'"
+            "php -r 'if (file_exists(\"bin/remove-package-artifacts.php\")) include \"bin/remove-package-artifacts.php\";'",
+            "php -r 'if (file_exists(\"CHANGELOG.md\")) unlink(\"CHANGELOG.md\");'"
         ],
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"


### PR DESCRIPTION
Also blocks CHANGELOG from being in tarballs or the created project, since it is specific to the package, not the projects built with it.