### PR TITLE
fix: change version constraint of laminas-skeleton-installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.0.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.0.0 - 2020-09-14
 
 This is the initial 1.0.0 release under the Laminas organization.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3",
         "laminas/laminas-component-installer": "^1.0 || ^2.1",
         "laminas/laminas-development-mode": "^3.2",
-        "laminas/laminas-skeleton-installer": "^0.1.7 || ^1.0",
+        "laminas/laminas-skeleton-installer": "^0.1.7 || ^0.2 ||  ^1.0",
         "laminas/laminas-mvc": "^3.1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3",
         "laminas/laminas-component-installer": "^1.0 || ^2.1",
         "laminas/laminas-development-mode": "^3.2",
-        "laminas/laminas-skeleton-installer": "^0.1.7 || ^0.2 ||  ^1.0",
+        "laminas/laminas-skeleton-installer": "^0.2 || ^1.0",
         "laminas/laminas-mvc": "^3.1.1"
     },
     "autoload": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no


Add `^0.2` to the version constraint of `laminas/laminas-skeleton-installer`.
Version `^0.2` already supports composer 2.

I tried it locally with composer `1.10.16` and `2.0.2` without problems.


fixes #28 
