### PR TITLE
Provide support for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-component-installer": "^1.0 || ^2.1",
+        "laminas/laminas-component-installer": "^2.4",
         "laminas/laminas-development-mode": "^3.2",
-        "laminas/laminas-skeleton-installer": "^0.2 || ^1.0",
+        "laminas/laminas-skeleton-installer": "^0.3",
         "laminas/laminas-mvc": "^3.1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "framework"
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-component-installer": "^1.0 || ^2.1",
         "laminas/laminas-development-mode": "^3.2",
         "laminas/laminas-skeleton-installer": "^0.2 || ^1.0",


### PR DESCRIPTION
Adds support for PHP 8.0 as requested in #27

- composer.json already doesn't support PHP less than 7.3
- composer.json currently does not require-dev phpunit
(it is installed during initial project creation when MVC testing support is installed as described in README.md)
- no .travis.yml is present

Tested in docker with php:8.0-rc-apache
The skeleton app is compatible/runs without any issues.

phpunit reports an error on the use of the deprecated function libxml_disable_entity_loader in laminas-test, which should be fixed when PHP 8.0 support is added to laminas-test

```php
 composer run test
> phpunit
PHPUnit 9.4.2 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.E.                                                                 3 / 3 (100%)

Time: 00:00.028, Memory: 10.00 MB

There was 1 error:

1) ApplicationTest\Controller\IndexControllerTest::testIndexActionViewModelTemplateRenderedWithinLayout
Function libxml_disable_entity_loader() is deprecated

/var/www/vendor/laminas/laminas-dom/src/Document.php:234
/var/www/vendor/laminas/laminas-dom/src/Document.php:159
/var/www/vendor/laminas/laminas-dom/src/Document/Query.php:45
/var/www/vendor/laminas/laminas-test/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php:386
/var/www/vendor/laminas/laminas-test/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php:411
/var/www/vendor/laminas/laminas-test/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php:434
/var/www/vendor/laminas/laminas-test/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php:451
/var/www/module/Application/test/Controller/IndexControllerTest.php:48

ERRORS!
Tests: 3, Assertions: 6, Errors: 1.
Script phpunit handling the test event returned with error code 2
```