### PR TITLE
Use laminas-mvc-middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,9 +82,10 @@
                 "module": true
             },
             {
-                "name": "laminas/laminas-psr7bridge",
-                "constraint": "^1.3.1",
-                "prompt": "Would you like to use the PSR-7 middleware dispatcher?"
+                "name": "laminas/laminas-mvc-middleware",
+                "constraint": "^2.0.0",
+                "prompt": "Would you like to use the PSR-7 middleware dispatcher?",
+                "module": true
             },
             {
                 "name": "laminas/laminas-session",


### PR DESCRIPTION
Replace extra package `laminas-psr7bridge` for deprecated `MiddlewareListener` with `laminas-mvc-middleware`