### PR TITLE
Added support for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "framework"
     ],
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-component-installer": "^2.4",
         "laminas/laminas-development-mode": "^3.2",
         "laminas/laminas-skeleton-installer": "^0.6",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "framework"
     ],
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-component-installer": "^2.4",
         "laminas/laminas-development-mode": "^3.2",
         "laminas/laminas-skeleton-installer": "^0.6",
@@ -43,7 +43,7 @@
             },
             {
                 "name": "laminas/laminas-mvc-form",
-                "constraint": "^1.1.0",
+                "constraint": "^2.0.0",
                 "prompt": "Would you like to install forms support?",
                 "module": true
             },
@@ -89,7 +89,7 @@
             },
             {
                 "name": "laminas/laminas-test",
-                "constraint": "^3.4.2",
+                "constraint": "^4.0.0",
                 "prompt": "Would you like to install MVC testing tools for testing support?",
                 "dev": true
             },


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description
This PR adds support for PHP 8.1 and thus fixes #47 .

It is not done yet. We need to decide on a way to deal with the potential cache adapters.