### PR TITLE
Add path array and default timezone

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -20,8 +20,20 @@ if (php_sapi_name() === 'cli-server') {
     unset($path);
 }
 
+// Set default timezone if not available in php.ini
+if (!ini_get('date.timezone')) {
+    date_default_timezone_set('UTC');
+}
+
+// Set paths
+$path =  [
+    'autoload'   => __DIR__ . '/../vendor/autoload.php',
+    'app_config' => __DIR__ . '/../config/application.config.php',
+    'dev_config' => __DIR__ . '/../config/development.config.php',
+];
+
 // Composer autoloading
-include __DIR__ . '/../vendor/autoload.php';
+include realpath($path['autoload']);
 
 if (! class_exists(Application::class)) {
     throw new RuntimeException(
@@ -33,9 +45,9 @@ if (! class_exists(Application::class)) {
 }
 
 // Retrieve configuration
-$appConfig = require __DIR__ . '/../config/application.config.php';
-if (file_exists(__DIR__ . '/../config/development.config.php')) {
-    $appConfig = ArrayUtils::merge($appConfig, require __DIR__ . '/../config/development.config.php');
+$appConfig = require realpath($path['app_config']);
+if (file_exists($path['dev_config'])) {
+    $appConfig = ArrayUtils::merge($appConfig, require realpath($path['dev_config']));
 }
 
 // Run the application!


### PR DESCRIPTION
Signed-off-by: Hossein Azizabadi Farahani <hossein.azizabadi@gmail.com>


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

We use laminas as the main framework for some production applications (and [laminas-mvc-skeleton](https://github.com/laminas/laminas-mvc-skeleton)), in all of the applications as restful API, usually, our other paths like vendor and config is out of html folder and our folder system is different. I have to edit index.php after each install by custom path, 

It is good if we can set all paths in one array and just update it