### PR TITLE
Disable process timeout for composer serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once installed, you can test it out immediately using PHP's built-in web server:
 $ cd path/to/install
 $ php -S 0.0.0.0:8080 -t public
 # OR use the composer alias:
-$ composer run --timeout 0 serve
+$ composer serve
 ```
 
 This will start the cli-server on port 8080, and bind it to all network

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,10 @@
         ],
         "post-install-cmd": "@clear-config-cache",
         "post-update-cmd": "@clear-config-cache",
-        "serve": "php -S 0.0.0.0:8080 -t public",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S 0.0.0.0:8080 -t public"
+        ],
         "test": "vendor/bin/phpunit",
         "static-analysis": "vendor/bin/psalm --shepherd --stats"
     },


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Composer default timeout is 300s which is not suitable for PHP builtin development server run by `composer serve`.

Composer provides convenience helper to disable timeout for specific scripts since 1.9.0
See https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands
