### PR TITLE
Add script to clear config cache and run it on post install

### DIFF
--- a/bin/clear-config-cache.php
+++ b/bin/clear-config-cache.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Laminas\ModuleManager\Listener\ListenerOptions;
+
+chdir(__DIR__ . '/../');
+
+require 'vendor/autoload.php';
+
+$config = include 'config/application.config.php';
+
+if (! isset($config['module_listener_options'])) {
+    echo "No module listener options found. Can not determine config cache location." . PHP_EOL;
+    exit(0);
+}
+
+$options = new ListenerOptions($config['module_listener_options']);
+$configCacheFile = $options->getConfigCacheFile();
+
+if (! file_exists($configCacheFile)) {
+    printf(
+        "Configured config cache file '%s' not found%s",
+        $configCacheFile,
+        PHP_EOL
+    );
+    exit(0);
+}
+
+if (false === unlink($configCacheFile)) {
+    printf(
+        "Error removing config cache file '%s'%s",
+        $configCacheFile,
+        PHP_EOL
+    );
+    exit(1);
+}
+
+printf(
+    "Removed configured config cache file '%s'%s",
+    $configCacheFile,
+    PHP_EOL
+);
+exit(0);

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,8 @@
             "php -r 'if (file_exists(\"bin/remove-package-artifacts.php\")) include \"bin/remove-package-artifacts.php\";'",
             "php -r 'if (file_exists(\"CHANGELOG.md\")) unlink(\"CHANGELOG.md\");'"
         ],
+        "post-install-cmd": "@clear-config-cache",
+        "post-update-cmd": "@clear-config-cache",
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "vendor/bin/phpunit",
         "static-analysis": "vendor/bin/psalm --shepherd --stats"

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         ]
     },
     "scripts": {
+        "clear-config-cache": "php bin/clear-config-cache.php",
         "cs-check": "vendor/bin/phpcs",
         "cs-fix": "vendor/bin/phpcbf",
         "development-disable": "laminas-development-mode disable",
@@ -118,6 +119,7 @@
         "static-analysis": "vendor/bin/psalm --shepherd --stats"
     },
     "scripts-descriptions": {
+        "clear-config-cache": "Clears merged config cache. Required for config changes to be applied.",
         "cs-check": "Run coding standards checks.",
         "cs-fix": "Automatically fix coding standard issues.",
         "development-disable": "Disable development mode.",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Users occasionally seek help with container services not found or config not working. One of the reasons that occurs is because they have stale config cache.

This PR adopts `clear-config-cache.php` script from mezzio skeleton with changes for module manager and introduces post-install and post-update composer hooks to clear config cache when composer install or composer update are run.

Those hooks will clear config cache even if no package changes happened. post-package-install would be better in that regard, but afaik it runs after each package installed and before autoloader is available. 