### PR TITLE
Drop php 7.4. Bump dependencies and installer suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "framework"
     ],
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-        "laminas/laminas-component-installer": "^3.0",
-        "laminas/laminas-development-mode": "^3.2",
-        "laminas/laminas-skeleton-installer": "^1.0",
-        "laminas/laminas-mvc": "^3.3.4"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "laminas/laminas-component-installer": "^3.2",
+        "laminas/laminas-development-mode": "^3.10",
+        "laminas/laminas-skeleton-installer": "^1.2",
+        "laminas/laminas-mvc": "^3.6.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,14 +30,14 @@
         "laminas-skeleton-installer": [
             {
                 "name": "laminas/laminas-developer-tools",
-                "constraint": "^2.1.1",
+                "constraint": "^2.8.0",
                 "prompt": "Would you like to install the developer toolbar?",
                 "module": true,
                 "dev": true
             },
             {
                 "name": "laminas/laminas-db",
-                "constraint": "^2.12.0",
+                "constraint": "^2.17.0",
                 "prompt": "Would you like to install database support (installs laminas-db)?",
                 "module": true
             },
@@ -49,53 +49,53 @@
             },
             {
                 "name": "laminas/laminas-json",
-                "constraint": "^3.2",
+                "constraint": "^3.5.0",
                 "prompt": "Would you like to install JSON de/serialization support?"
             },
             {
                 "name": "laminas/laminas-log",
-                "constraint": "^2.13.1",
+                "constraint": "^2.16.1",
                 "prompt": "Would you like to install logging support?",
                 "module": true
             },
             {
                 "name": "laminas/laminas-cli",
-                "constraint": "^1.1.1",
+                "constraint": "^1.8.0",
                 "prompt": "Would you like to install command-line interface support?"
             },
             {
                 "name": "laminas/laminas-mvc-i18n",
-                "constraint": "^1.2.0",
+                "constraint": "^1.7.0",
                 "prompt": "Would you like to install i18n support?",
                 "module": true
             },
             {
                 "name": "laminas/laminas-mvc-plugins",
-                "constraint": "^1.1.0",
+                "constraint": "^1.2.0",
                 "prompt": "Would you like to install the official MVC plugins, including PRG support, identity, and flash messages?",
                 "module": true
             },
             {
                 "name": "laminas/laminas-mvc-middleware",
-                "constraint": "^2.0.0",
+                "constraint": "^2.3.0",
                 "prompt": "Would you like to use the PSR-7 middleware dispatcher?",
                 "module": true
             },
             {
                 "name": "laminas/laminas-session",
-                "constraint": "^2.10.0",
+                "constraint": "^2.16.0",
                 "prompt": "Would you like to install sessions support?",
                 "module": true
             },
             {
                 "name": "laminas/laminas-test",
-                "constraint": "^4.0.0",
+                "constraint": "^4.7.0",
                 "prompt": "Would you like to install MVC testing tools for testing support?",
                 "dev": true
             },
             {
                 "name": "laminas/laminas-di",
-                "constraint": "^3.2.2",
+                "constraint": "^3.12.0",
                 "prompt": "Would you like to install the laminas-di for laminas-servicemanager?",
                 "module": true
             }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Bump minimum php version to 8 and update dependencies and installer suggestions to versions accepting php 8.0 as minimum.