### PR TITLE
Fixes the home menu entry in the main navigation.

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -48,9 +48,12 @@
                 </div>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav">
-                        <li class="nav-item active">
-                            <a class="nav-link" href="<?= $this->url('home') ?>">
-                                Home <span class="sr-only">(current)</span>
+                        <li class="nav-item">
+                            <a
+                                class="nav-link active"
+                                aria-current="page"
+                                href="<?= $this->url('home') ?>"
+                            >Home
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
With the update of Bootstrap to v5.2.3 the span could have been removed in favor of using aria-current.  Also, the .active class needs to be set on the "a" instead of the "li".


