### PR TITLE
Fixes HTML and CSS for navbar and toggler

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -27,7 +27,7 @@
         <?= $this->headScript() ?>
     </head>
     <body>
-        <nav class="navbar navbar-expand-sm navbar-dark mb-4" role="navigation">
+        <nav class="navbar navbar-expand-md navbar-dark mb-4" role="navigation">
             <div class="container">
                 <a class="navbar-brand" href="<?= $this->url('home') ?>">
                     <img src="<?= $this->basePath('img/laminas-logo.svg') ?>" alt="Laminas">
@@ -45,7 +45,7 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav">
+                    <ul class="navbar-nav ms-auto">
                         <li class="nav-item">
                             <a
                                 class="nav-link active"

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -22,30 +22,28 @@
                             ])
             ->prependStylesheet($this->basePath('css/style.css'))
             ->prependStylesheet($this->basePath('css/bootstrap.min.css'))
-?>
-
+        ?>
         <!-- Scripts -->
         <?= $this->headScript() ?>
     </head>
     <body>
-        <nav class="navbar navbar-expand-md navbar-dark mb-4" role="navigation">
+        <nav class="navbar navbar-expand-sm navbar-dark mb-4" role="navigation">
             <div class="container">
-                <div class="navbar-header">
-                    <button
-                        class="navbar-toggler"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#navbarSupportedContent"
-                        aria-controls="navbarSupportedContent"
-                        aria-expanded="false"
-                        aria-label="Toggle navigation"
-                    >
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <a class="navbar-brand" href="<?= $this->url('home') ?>">
-                        <img src="<?= $this->basePath('img/laminas-logo.svg') ?>" alt="Laminas">MVC Skeleton
-                    </a>
-                </div>
+                <a class="navbar-brand" href="<?= $this->url('home') ?>">
+                    <img src="<?= $this->basePath('img/laminas-logo.svg') ?>" alt="Laminas">
+                    <span class="navbar-text text-light">MVC Skeleton</span>
+                </a>
+                <button
+                    class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbarSupportedContent"
+                    aria-controls="navbarSupportedContent"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation"
+                >
+                    <span class="navbar-toggler-icon"></span>
+                </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav">
                         <li class="nav-item">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -10,3 +10,8 @@
     background-color: var(--brand-color);
     border-color: var(--brand-color);
 }
+
+/* allows bootstrap to style Laminas Navigation generated menus active link */
+.navbar li.active a {
+    color: var(--bs-navbar-active-color);
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11,7 +11,7 @@
     border-color: var(--brand-color);
 }
 
-/* allows bootstrap to style Laminas Navigation generated menus active link */
+/* allows bootstrap to style Laminas Navigation generated menu items within the navbar */
 .navbar li.active a {
     color: var(--bs-navbar-active-color);
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Tell us about why this change is necessary:
Changes address the Toggler issues in the skeleton layout and a style issue in the Laminas Navigation menu helper tutorial.

Review of changes.
1. Removed an unnecessary div class="navbar-header" since bootstrap 5.2.3 does not support this class and the skeleton apps style.css does not target it either.
2. Added a span wrapping the MVC Skeleton text with classes navbar-text text-light to improve the spacing of the text next to the logo.
3. Changed the order of the markup so as to move the toggler to the right side and changed the collapse breakpoint to sm from md. The breakpoint is still triggered by simply shrinking the browser window.
4. Added the needed style in style.css to allow the Laminas Navigation tutorial to work as stated in the docs. It targets specifically the .navbar li.active a so as to not style any other navigation items created by the navigation component. Seemed the least intrusive way to handle it.

Please reference the following:
Toggler:
https://getbootstrap.com/docs/5.2/components/navbar/#toggler

For the MVC Skeleton text:
https://getbootstrap.com/docs/5.2/components/navbar/#text-1
