### PR TITLE
Fixes wrong assertions in the controller test class

### DIFF
--- a/module/Application/test/Controller/IndexControllerTest.php
+++ b/module/Application/test/Controller/IndexControllerTest.php
@@ -39,7 +39,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     public function testIndexActionViewModelTemplateRenderedWithinLayout(): void
     {
         $this->dispatch('/', 'GET');
-        $this->assertQuery('.container .jumbotron');
+        $this->assertQuery('.col .card');
     }
 
     public function testInvalidRouteDoesNotCrash(): void

--- a/module/Application/test/Controller/IndexControllerTest.php
+++ b/module/Application/test/Controller/IndexControllerTest.php
@@ -39,7 +39,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     public function testIndexActionViewModelTemplateRenderedWithinLayout(): void
     {
         $this->dispatch('/', 'GET');
-        $this->assertQuery('.container .card');
+        $this->assertQuery('body h1');
     }
 
     public function testInvalidRouteDoesNotCrash(): void

--- a/module/Application/test/Controller/IndexControllerTest.php
+++ b/module/Application/test/Controller/IndexControllerTest.php
@@ -39,7 +39,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     public function testIndexActionViewModelTemplateRenderedWithinLayout(): void
     {
         $this->dispatch('/', 'GET');
-        $this->assertQuery('.col .card');
+        $this->assertQuery('.container .card');
     }
 
     public function testInvalidRouteDoesNotCrash(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
class from layout.phtml 
.container

class from index.phtml
.card

For this test to work as intended it must be passed a class from BOTH files.

Please note the entire test methods name is relevant.
"Index Action View Model Template Rendered Within Layout"

fix:
current
```php
    public function testIndexActionViewModelTemplateRenderedWithinLayout(): void
    {
        $this->dispatch('/', 'GET');
        $this->assertQuery('.container .jumbotron');
    }
```

changed to:
```php
    public function testIndexActionViewModelTemplateRenderedWithinLayout(): void
    {
        $this->dispatch('/', 'GET');
        $this->assertQuery('body h1');
    }
```