### PR TITLE
Fix docker compose command in CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,5 @@ jobs:
 
       - name: Build and run docker compose file
         run: |
-          docker-compose up -d --build
-          docker-compose run laminas echo "ok"
-
+          docker compose up -d --build
+          docker compose run laminas echo "ok"


### PR DESCRIPTION
Docker build workflow is failing because of outdated or missing command