### PR TITLE
Add support for PHP 8.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "framework"
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-component-installer": "^3.4.0",
         "laminas/laminas-development-mode": "^3.12.0",
         "laminas/laminas-mvc": "^3.7.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^10.4",
         "psalm/plugin-phpunit": "^0.19.0",
         "squizlabs/php_codesniffer": "^3.7",
-        "vimeo/psalm": "^5.13"
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To solve this composer error:
requires php ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.23) does not satisfy that requirement.